### PR TITLE
Print seed at the start of a run

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -91,6 +91,7 @@ local function resetAll()
 		print("RUNNING WITH A FIXED SEED ("..strategies.seed.."), every run will play out identically!")
 	else
 		strategies.seed = os.time()
+		print("PokeBot version "..VERSION.." starting new run with seed "..strategies.seed..".")
 	end
 	math.randomseed(strategies.seed)
 end


### PR DESCRIPTION
Since BizHawk seems to have a memory leak, it would be nice to know the seed of runs where the script terminates.

This also prints the current pokebot version, since a same seed  run won't be consistent between versions.