### PR TITLE
Screenshot of completed Seed

### DIFF
--- a/ai/red/strategies.lua
+++ b/ai/red/strategies.lua
@@ -2284,6 +2284,17 @@ strategyFunctions.champion = function()
 			return Strategies.hardReset("Back to the grind - you can follow on Twitter for updates on our next good run! https://twitter.com/thepokebot")
 		end
 		if status.tries == 0 then
+			if STREAMING_MODE and CUSTOM_SEED ~= nil then
+				gui.text(0, 0, "PokeBot v"..VERSION)
+				gui.text(0, 7, "Seed: "..Strategies.seed)
+				gui.text(0, 14, "Reset for time: "..tostring(RESET_FOR_TIME))
+				gui.text(0, 21, "Time: "..Utils.elapsedTime())
+				gui.text(0, 28, "Frames: "..Utils.frames())
+				client.setscreenshotosd(true)
+				client.screenshot()
+				client.setscreenshotosd(false)
+				gui.cleartext()
+			end			
 			Strategies.tweetProgress("Beat Pokemon Red in "..status.canProgress.."!")
 			if Strategies.seed then
 				print("v"..VERSION..": "..Utils.frames().." frames, with seed "..Strategies.seed)


### PR DESCRIPTION
This adds an automated screenshot once a run is completed including
version, seed, frames and if reset for time. This has been added for
easier sharing of seeds.

Example image is using the seed found by Gofigga
![pokemon - red version usa europe 2015-04-12 00 57 16](https://cloud.githubusercontent.com/assets/11803165/7108130/2658d9f4-e14a-11e4-94ff-19394af9c251.png)
