### PR TITLE
seed(1428414915): Add v1.4.2 stats

### DIFF
--- a/Seeds.md
+++ b/Seeds.md
@@ -2,15 +2,16 @@
 
 PokéBot comes with a built-in run recording feature that takes advantage of random number seeding to reproduce runs in their entirety. Any time the bot resets or beats the game, it logs a number to the Lua console that is the seed for the run. This seed allows you to easily share the run with others.
 
-Have you found a seed that results in a run of 1:52:00 or better using the bot’s default settings? [Let us know](https://github.com/kylecoburn/PokeBot/issues/4), and we’ll add it to the list!
+Have you found a seed that results in a run of 1:51:30 or better using the bot’s default settings? [Let us know](https://github.com/kylecoburn/PokeBot/issues/4), and we’ll add it to the list!
 
 | Time    | Frames  | Seed         | Nidoran name | Bot version | Found by                                     |
 |---------|---------|--------------|--------------|-------------|----------------------------------------------|
 | 1:50:11 | 396,858 | `1428898417` | ,            | v1.4.2      | ThePokéBot                                   |
+| 1:50:22 | 397,352 | `1428414915` | A            | v1.4.2      | [Gofigga](http://www.twitch.tv/gofigga)      |
 | 1:50:36 | 398,208 | `1428414915` | A            | v1.4.0      | [Gofigga](http://www.twitch.tv/gofigga)      |
 | 1:50:37 | 398,226 | `1428414915` | A            | v1.3.0      | [Gofigga](http://www.twitch.tv/gofigga)      |
 | 1:50:51 | 399,076 | `1428414915` | A            | v1.4.1      | [Gofigga](http://www.twitch.tv/gofigga)      |
 | 1:50:55 | 399,355 | `1428801658` | A            | v1.4.0      | [Marcin1503](https://github.com/Marcin1503)  |
 | 1:50:41 | 398,509 | `1428873163` | A            | v1.4.1      | [Marcin1503](https://github.com/Marcin1503)  |
 
-To reproduce any of these runs, set [`CUSTOM_SEED` in `main.lua`](https://github.com/kylecoburn/PokeBot/blob/27aa1dcd2cec1bbe25607fa346836f63b349ad5f/main.lua#L5) to the seed number and run the bot.
+To reproduce any of these runs, set [`CUSTOM_SEED` in `main.lua`](https://github.com/kylecoburn/PokeBot/blob/27aa1dcd2cec1bbe25607fa346836f63b349ad5f/main.lua#L5) to the seed number, `NIDORAN_NAME` to the matching name, and run the bot.

--- a/Seeds.md
+++ b/Seeds.md
@@ -10,8 +10,9 @@ Have you found a seed that results in a run of 1:51:30 or better using the botâ€
 | 1:50:22 | 397,352 | `1428414915` | A            | v1.4.2      | [Gofigga](http://www.twitch.tv/gofigga)      |
 | 1:50:36 | 398,208 | `1428414915` | A            | v1.4.0      | [Gofigga](http://www.twitch.tv/gofigga)      |
 | 1:50:37 | 398,226 | `1428414915` | A            | v1.3.0      | [Gofigga](http://www.twitch.tv/gofigga)      |
+| 1:50:41 | 398,509 | `1428873163` | A            | v1.4.1      | [Marcin1503](https://github.com/Marcin1503)     |
 | 1:50:51 | 399,076 | `1428414915` | A            | v1.4.1      | [Gofigga](http://www.twitch.tv/gofigga)      |
 | 1:50:55 | 399,355 | `1428801658` | A            | v1.4.0      | [Marcin1503](https://github.com/Marcin1503)  |
-| 1:50:41 | 398,509 | `1428873163` | A            | v1.4.1      | [Marcin1503](https://github.com/Marcin1503)  |
+| 1:51:07 | 400,057 |   `91688624` | A            | v1.4.2      | [Mathias](https://mathiasbynens.be/)         |
 
 To reproduce any of these runs, set [`CUSTOM_SEED` in `main.lua`](https://github.com/kylecoburn/PokeBot/blob/27aa1dcd2cec1bbe25607fa346836f63b349ad5f/main.lua#L5) to the seed number, `NIDORAN_NAME` to the matching name, and run the bot.


### PR DESCRIPTION
This run went from 1:50:51 in v1.4.1 to 1:50:22 in v1.4.2!

Full log below:

```
1. Pallet Rival: 0:02:06 (02:06)

2. Nidoran grass: 0:05:46 (03:40)

15 7 14 14

beat Brock with a perfect Nidoran! Att: 16, Def: 12, Speed: 15, Special: 13, caught at level 4.

3. Brock's Gym: 0:10:23 (04:37)

4. Route 3: 0:17:46 (07:23)

12 Moon encounters, but we caught a Paras!

5. Mt. Moon: 0:25:58 (08:12)

RCE 5413

15 7 14 14

56 45 53 48

6. Nugget Bridge: 0:33:22 (07:24)

7. Misty's Gym: 0:38:59 (05:37)

gen 1 missed :( (1 in 256 chance)

 PERFECT, 1 try Trashcans! || 0:47:39

8. Surge's Gym: 0:48:40 (09:41)

needs a 4-turn thrash (1 in 2 chance) to beat this dangerous trainer...

is using Thunderbolt to attempt to redbar off Cubone

Giovanni skip strats!

9. HM02 Fly: 0:59:11 (10:31)

is using Rock Slide to one-hit these Ghastlies in red-bar (each is 1 in 10 to miss)

10. Pokemon Tower: 1:06:53 (07:42)

11. Silph Giovanni: 1:17:36 (10:43)

EQ Elixer: Koga's Gym

12. Koga's Gym: 1:21:20 (03:44)

13. Erika's Gym: 1:26:29 (05:09)

14. Blaine's Gym: 1:29:23 (02:54)

15. Sabrina's Gym: 1:31:05 (01:42)

EQ Elixer: Sabrina's Gym

16. Giovanni's Gym: 1:34:40 (03:35)

is skipping the Center and attempting to red-bar the Elite 4!

17. Lorelei: 1:42:33 (07:53)

18. Bruno: 1:43:47 (01:14)

19. Agatha: 1:45:28 (01:41)

20. Lance: 1:47:16 (01:48)

21. Blue: 1:50:22 (03:06)

v1.4.2: 397352 frames, with seed 1428414915

beat the game in 1:50:22!
```